### PR TITLE
fix(dbt-fal): handle dbt debug and dbt --version commands

### DIFF
--- a/projects/adapter/src/dbt/adapters/fal/__init__.py
+++ b/projects/adapter/src/dbt/adapters/fal/__init__.py
@@ -1,11 +1,21 @@
 from dbt.adapters.base import AdapterPlugin
 
 from dbt.adapters.fal.connections import FalEncCredentials
-from dbt.adapters.fal.impl import FalEncAdapter
 from dbt.include import fal
 
-Plugin = AdapterPlugin(
-    adapter=FalEncAdapter,
-    credentials=FalEncCredentials,
-    include_path=fal.PACKAGE_PATH
-)
+# Avoid loading the plugin code for any import
+def __getattr__(name):
+    if name == "FalEncAdapter":
+        from dbt.adapters.fal.impl import FalEncAdapter
+
+        return FalEncAdapter
+    if name == "Plugin":
+        from dbt.adapters.fal.impl import FalEncAdapter
+
+        return AdapterPlugin(
+            adapter=FalEncAdapter,
+            credentials=FalEncCredentials,
+            include_path=fal.PACKAGE_PATH
+        )
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
+++ b/projects/adapter/src/dbt/adapters/fal/load_db_profile.py
@@ -40,7 +40,7 @@ def find_target_name(
 def load_profiles_info_1_5() -> Tuple[Profile, Dict[str, Any]]:
     flags: Namespace = get_flags()
 
-    profile_renderer = ProfileRenderer(flags.VARS)
+    profile_renderer = ProfileRenderer(getattr(flags, "VARS", {}))
 
     profile_name = find_profile_name(flags.PROFILE, flags.PROJECT_DIR, profile_renderer)
 
@@ -74,7 +74,7 @@ def load_profiles_info_1_5() -> Tuple[Profile, Dict[str, Any]]:
         ) from error
 
     override_properties = {
-        "threads": flags.THREADS or fal_dict.get("threads") or db_profile.threads,
+        "threads": getattr(flags, "THREADS", None) or fal_dict.get("threads") or db_profile.threads,
     }
 
     return db_profile, override_properties


### PR DESCRIPTION
```
$ dbt --version
Traceback (most recent call last):
  File "/Users/xxx/.pyenv/versions/3.10.9/bin/dbt", line 8, in <module>
    sys.exit(cli())
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/click/core.py", line 1054, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/click/core.py", line 920, in make_context
    self.parse_args(ctx, args)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/click/core.py", line 1613, in parse_args
    rest = super().parse_args(ctx, args)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/click/core.py", line 1378, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/click/core.py", line 2360, in handle_parse_result
    value = self.process_value(ctx, value)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/click/core.py", line 2322, in process_value
    value = self.callback(ctx, self, value)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/cli/params.py", line 500, in _version_callback
    click.echo(get_version_information())
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/version.py", line 24, in get_version_information
    plugin_version_msg = _get_plugins_msg(installed)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/version.py", line 104, in _get_plugins_msg
    for name, version_s in _get_dbt_plugins_info():
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/version.py", line 211, in _get_dbt_plugins_info
    mod = importlib.import_module(f"dbt.adapters.{plugin_name}.__version__")
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/fal/__init__.py", line 4, in <module>
    from dbt.adapters.fal.impl import FalEncAdapter
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/fal/impl.py", line 39, in <module>
    DB_PROFILE, OVERRIDE_PROPERTIES = load_profiles_info_1_5()
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/fal/load_db_profile.py", line 43, in load_profiles_info_1_5
    profile_renderer = ProfileRenderer(flags.VARS)
AttributeError: 'Namespace' object has no attribute 'VARS'
```

```
dbt debug
15:57:50  Running with dbt=1.5.0
15:57:50  dbt version: 1.5.0
15:57:50  python version: 3.10.9
15:57:50  python path: /Users/xxx/.pyenv/versions/3.10.9/bin/python3.10
15:57:50  os info: macOS-12.5.1-x86_64-i386-64bit
15:57:50  Using profiles.yml file at /Users/xxx/.dbt/profiles.yml
15:57:50  Using dbt_project.yml file at /Users/xxx/stuff/dbt/dbt_project.yml
15:57:50  Configuration:
15:57:52  Encountered an error:
'Flags' object has no attribute 'THREADS'
15:57:52  Traceback (most recent call last):
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/cli/requires.py", line 86, in wrapper
    result, success = func(*args, **kwargs)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/cli/requires.py", line 71, in wrapper
    return func(*args, **kwargs)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/cli/main.py", line 417, in debug
    results = task.run()
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/task/debug.py", line 110, in run
    self.test_configuration()
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/task/debug.py", line 294, in test_configuration
    profile_status = self._load_profile()
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/task/debug.py", line 254, in _load_profile
    profile: Profile = Profile.render(
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/config/profile.py", line 436, in render
    return cls.from_raw_profiles(
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/config/profile.py", line 401, in from_raw_profiles
    return cls.from_raw_profile_info(
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/config/profile.py", line 355, in from_raw_profile_info
    credentials: Credentials = cls._credentials_from_profile(
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/config/profile.py", line 165, in _credentials_from_profile
    cls = load_plugin(typename)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/factory.py", line 202, in load_plugin
    return FACTORY.load_plugin(name)
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/factory.py", line 57, in load_plugin
    mod: Any = import_module("." + name, "dbt.adapters")
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/fal/__init__.py", line 4, in <module>
    from dbt.adapters.fal.impl import FalEncAdapter
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/fal/impl.py", line 39, in <module>
    DB_PROFILE, OVERRIDE_PROPERTIES = load_profiles_info_1_5()
  File "/Users/xxx/.pyenv/versions/3.10.9/lib/python3.10/site-packages/dbt/adapters/fal/load_db_profile.py", line 77, in load_profiles_info_1_5
    "threads": flags.THREADS or fal_dict.get("threads") or db_profile.threads,
AttributeError: 'Flags' object has no attribute 'THREADS'
```