### PR TITLE
Change default varchar size in redshift to 65535

### DIFF
--- a/projects/adapter/pyproject.toml
+++ b/projects/adapter/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-dbt-core = ">=1.5,<=1.5.1"
+dbt-core = ">=1.5,<=1.5.5"
 pandas = "^1.3.4"
 posthog = "^1.4.5"
 "backports.functools_lru_cache" = "^1.6.4"

--- a/projects/adapter/src/dbt/adapters/fal_experimental/support/redshift.py
+++ b/projects/adapter/src/dbt/adapters/fal_experimental/support/redshift.py
@@ -46,6 +46,7 @@ def write_df_to_relation(
             table=temp_relation.identifier,
             schema=temp_relation.schema,
             index=False,
+            varchar_lengths_default=65535
         )
 
         adapter.cache.add(temp_relation)


### PR DESCRIPTION

## Description
As mentioned in https://discord.com/channels/908693336280432750/940966301680156683/941335732923007056

The default value for varchar in dbt-fal is 256, which is too small for many applications. This changes the default to max so that most of models work without problem.
<!-- If applicable: -->
<!--
GitHub: resolves #XXX
Linear: closes FEA-XXX
-->

