### PR TITLE
support dbt core v1.7.0

### DIFF
--- a/projects/adapter/pyproject.toml
+++ b/projects/adapter/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-dbt-core = ">=1.5,<=1.5.1"
+dbt-core = ">=1.5,<=1.5.5"
 pandas = "^1.3.4"
 posthog = "^1.4.5"
 "backports.functools_lru_cache" = "^1.6.4"

--- a/projects/adapter/pyproject.toml
+++ b/projects/adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-fal"
-version = "1.5.10a0"
+version = "1.7.0a0"
 # name = "fal"
 # version = "0.9.4a0"
 description = "Run python scripts from any dbt project."
@@ -22,7 +22,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-dbt-core = ">=1.5,<=1.5.5"
+dbt-core = ">=1.5<=1.7.0"
 pandas = "^1.3.4"
 posthog = "^1.4.5"
 "backports.functools_lru_cache" = "^1.6.4"


### PR DESCRIPTION
## Description
Upgrade DBT to support core v1.70

<!-- If applicable: -->
<!--
GitHub: resolves #909 #880 


### Integration tests

Adapter to test:
- postgres
- snowflake
- bigquery
- redshift
- duckdb
- athena

Python version to test:
- 3.8
- 3.9
- 3.10
